### PR TITLE
Clean recipe ingredients

### DIFF
--- a/app/controllers/api/v1/saved_recipes_controller.rb
+++ b/app/controllers/api/v1/saved_recipes_controller.rb
@@ -1,21 +1,22 @@
 class Api::V1::SavedRecipesController < ApplicationController
-    skip_before_action :verify_authenticity_token
-    def create 
-        SavedRecipe.create(save_recipe_params)
-    end
-    def index 
-        user = User.find(params[:user_id])
-        render json: SavedRecipesSerializer.new(user.saved_recipes)
-    end
+  skip_before_action :verify_authenticity_token
 
-    def destroy 
-        SavedRecipe.destroy(params[:id])
-    end
+  def create
+    SavedRecipe.create(save_recipe_params)
+  end
 
-    private 
+  def index
+    user = User.find(params[:user_id])
+    render json: SavedRecipesSerializer.new(user.saved_recipes)
+  end
 
-    def save_recipe_params 
-        params.permit(:user_id, :recipe_name, :recipe_id)
-    end 
+  def destroy
+    SavedRecipe.destroy(params[:id])
+  end
 
+  private
+
+  def save_recipe_params
+    params.permit(:user_id, :recipe_name, :recipe_id)
+  end
 end

--- a/app/poros/recipe.rb
+++ b/app/poros/recipe.rb
@@ -1,11 +1,11 @@
 class Recipe
   attr_reader :id,
-              :name,
-              :ingredients,
-              :image,
-              :instructions,
-              :category,
-              :area
+    :name,
+    :ingredients,
+    :image,
+    :instructions,
+    :category,
+    :area
   def initialize(recipe_data)
     @id = recipe_data[:idMeal]
     @name = recipe_data[:strMeal]
@@ -18,21 +18,17 @@ class Recipe
 
   def get_ingredients(recipe_data)
     ingredient_values = []
-
     recipe_data.keys.select do |key|
-      if key.to_s.include?('strIngredient')
+      if key.to_s.include?("strIngredient")
         ingredient_values.push(recipe_data[key])
       end
     end
-
     measurement_values = []
-
     recipe_data.keys.select do |key|
-      if key.to_s.include?('strMeasure')
+      if key.to_s.include?("strMeasure")
         measurement_values.push(recipe_data[key])
       end
     end
-
-    Hash[ingredient_values.zip(measurement_values)].compact
+    ingredient_values.zip(measurement_values).to_h.compact.delete_if { |k, v| k.empty? }
   end
 end


### PR DESCRIPTION
This branch accomplishes the following: 

-cleans out empty string keys from the ingredients for a `Recipe` PORO